### PR TITLE
Logger para pruebas de variables

### DIFF
--- a/models/shortcut_loggertest.sublime-snippet
+++ b/models/shortcut_loggertest.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+    <content><![CDATA[
+_logger.info('\n\n\n\n ${1}: %s\n\n\n\n'%(${1}))
+]]></content>
+    <tabTrigger>_loggertest</tabTrigger>
+    <scope>source.python</scope>
+    <description>Logger para pruebas de variables dentro de ejecuciones de métodos.</description>
+</snippet>


### PR DESCRIPTION
Resulta extremadamente útil el uso del logger mientras se programan métodos, sobre todo para conocer resultado de variables mientras los métodos toman su curso.



